### PR TITLE
Fix file output parameter

### DIFF
--- a/cmd/business.go
+++ b/cmd/business.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/hashicorp/go-retryablehttp"
@@ -51,7 +52,8 @@ func runBusinessLogic(mangaID string) error {
 		bar.Set(pb.CleanOnFinish, true)
 
 		bar.Start()
-		f, err := os.Create(volume.Info.Identifier.StringFilled(4, 2, false) + ".azw3")
+		p := filepath.FromSlash(outArg)
+		f, err := os.Create(filepath.Clean(p) + "/" + volume.Info.Identifier.StringFilled(4, 2, false) + ".azw3")
 		if err != nil {
 			return fmt.Errorf("create volume %s: %w", volume.Info.Identifier, err)
 		}


### PR DESCRIPTION
Currently the argument for setting output directory, -o, doesn't do anything when set. This fix creates a path from the given string and amends it to the beginning of the output file. If an output directory is not specified then there is no change, but if one is specified then all outputs are written to the given directory. Accounts for trailing slash. Tested on Windows 10 and Ubuntu 20.04 LTS (WSL2). 