### PR TITLE
Make reading direction right to left

### DIFF
--- a/cmd/formats/mobi.go
+++ b/cmd/formats/mobi.go
@@ -63,6 +63,7 @@ func WriteMOBI(manga mangadex.Manga) mobi.Book {
 		CreatedDate:  time.Unix(0, 0),
 		Language:     mangaToLanguage(manga),
 		FixedLayout:  true,
+		RightToLeft:  true,
 		CoverImage:   mangaToCover(manga),
 		Images:       images,
 		Chapters:     chapters,


### PR DESCRIPTION
When reading Mangas from the official kindle store, they have a right to left reading direction, just like physical mangas. This PR mimics this behavior.

Same as with my other PR: This could possibly be a command line switch if some people prefer to use left to right reading direcitons. But this flat was more of a random discovery, so I couldn't be bothered to figure out how to do that 😅