### PR TITLE
Add simple autocrop option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ var (
 	volumesFilter       string
 	helpRankingFlag     bool
 	helpFilterFlag      bool
+	autocropFlag        bool
 )
 
 var rootCmd = &cobra.Command{
@@ -189,6 +190,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&groupsFilter, "groups", "G", "", "scantlation groups for chapter downloads")
 	rootCmd.Flags().BoolVarP(&helpRankingFlag, "help-ranking", "R", false, "Help for chapter ranking")
 	rootCmd.Flags().BoolVarP(&helpFilterFlag, "help-filter", "F", false, "Help for chapter filtering")
+	rootCmd.Flags().BoolVarP(&autocropFlag, "autocrop", "c", false, "autocrop chapter's images")
 	rootCmd.Flags().SortFlags = false
 	rootCmd.Flags().MarkHidden("cpuprofile") //nolint:errcheck
 	rootCmd.MarkFlagRequired("language")     //nolint:errcheck

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/fatih/color v1.13.0
+	github.com/flesnuk/boundingbox v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/leotaku/mobi v0.0.0-20220405163106-82e29bde7964

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/flesnuk/boundingbox v1.0.0 h1:1wzgNfcFBEITkqLcGnWrmYLBgFBCGWgdAL8Iy/bhO7U=
+github.com/flesnuk/boundingbox v1.0.0/go.mod h1:1SEy+SGjc7WVNp8Rw42QC/CeACGgZQ+CBbnKLRjHnH0=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=


### PR DESCRIPTION
Hi, I noticed the issue #9 and looked at a simple way to achieve that without adding too much overhead to the program. 
I created a simple library (https://github.com/flesnuk/boundingbox) to find the bounding box of a image and with this pull request I added it so it can be used when the autocrop (-c) option is enabled. 

I know #11 has been recently opened, so this pull request is simply useful in case you don't want to add a CGO dependency which can be a bit annoying. I guess it must be assessed the quality of the crops between the two, in case using Imagick results in better results. The algorithm used in the boundingbox library is a simple iteration through the pixels and detecting the edges by comparing if the RGB value is greater than a certain threshold, but I think that should be enough for this purpose.