### PR TITLE
Add left-to-right argument to CLI

### DIFF
--- a/cmd/business.go
+++ b/cmd/business.go
@@ -129,6 +129,8 @@ func businessAutoCropPages(pages md.ImageList) error {
 
 func businessWriteBook(manga md.Manga, bookFilename string, thumbnailDirectory string) error {
 	mobi := formats.WriteMOBI(manga)
+	mobi.RightToLeft = !leftToRightArg
+
 	bar := pb.New(0).SetTemplate(progressTemplate)
 	bar.Set("prefix", "Writing...")
 	bar.Set(pb.CleanOnFinish, true)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ var (
 	dryRunArg           bool
 	outArg              string
 	forceArg            bool
+	leftToRightArg      bool
 	cpuprofileArg       string
 	groupsFilter        string
 	chaptersFilter      string
@@ -182,6 +183,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&rankArg, "rank", "r", "most", "chapter ranking method to use")
 	rootCmd.Flags().BoolVarP(&autocropArg, "autocrop", "a", false, "crop whitespace from pages automatically")
 	rootCmd.Flags().BoolVarP(&kindleFolderModeArg, "kindle-folder-mode", "k", false, "generate folder structure for Kindle devices")
+	rootCmd.Flags().BoolVarP(&leftToRightArg, "left-to-right", "p", false, "make reading direction left to right")
 	rootCmd.Flags().BoolVarP(&dryRunArg, "dry-run", "d", false, "disable writing of any files")
 	rootCmd.Flags().StringVarP(&outArg, "out", "o", "", "output directory")
 	rootCmd.Flags().BoolVarP(&forceArg, "force", "f", false, "overwrite existing volumes")


### PR DESCRIPTION
As requested by @Colin1224  this adds an option to change the reading direction to "left-to-right".

Ideally, MangaDex would provide us with the information on whether a given Manga should be presented in left-to-right or right-to-left order, but while this is not the case we default to right-to-left.