### PR TITLE
Support for loading additional data from disk

### DIFF
--- a/cmd/business.go
+++ b/cmd/business.go
@@ -52,6 +52,17 @@ func run() error {
 		return fmt.Errorf("covers: %w", err)
 	}
 	p.Done()
+
+	if diskArg != "" {
+		p := formats.VanishingProgress("Disk...")
+		diskCovers, err := disk.LoadCovers(diskArg, p)
+		if err != nil {
+			p.Cancel("Error")
+			return fmt.Errorf("disk: %w", err)
+		}
+		p.Done()
+		covers = append(covers, diskCovers...)
+	}
 	*manga = manga.WithCovers(covers)
 
 	dir := kindle.NewNormalizedDirectory(outArg, manga.Info.Title, kindleFolderModeArg)

--- a/cmd/formats/disk/root.go
+++ b/cmd/formats/disk/root.go
@@ -1,0 +1,149 @@
+package disk
+
+import (
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/leotaku/kojirou/cmd/formats"
+	md "github.com/leotaku/kojirou/mangadex"
+	"golang.org/x/text/language"
+)
+
+func LoadSkeleton(directory string) (*md.Manga, error) {
+	info := md.MangaInfo{
+		Title: path.Base(directory),
+	}
+
+	return &md.Manga{
+		Info:    info,
+		Volumes: make(map[md.Identifier]md.Volume, 0),
+	}, nil
+}
+
+func LoadChapters(directory string, lang language.Tag, p formats.Progress) (md.ChapterList, error) {
+	result := make(md.ChapterList, 0)
+	volumes, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, fmt.Errorf("list '%v': %w", directory, err)
+	}
+	for _, volume := range volumes {
+		if !volume.IsDir() {
+			continue
+		}
+		chapters, err := os.ReadDir(path.Join(directory, volume.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("list '%v': %w", directory, err)
+		}
+		for _, chapter := range chapters {
+			if !chapter.IsDir() {
+				continue
+			}
+			p.Increase(1)
+			p.Add(1)
+
+			info := md.ChapterInfo{
+				Identifier:       md.NewIdentifier(chapter.Name()),
+				VolumeIdentifier: md.NewIdentifier(volume.Name()),
+				GroupNames:       []string{"Filesystem"},
+				Language:         lang,
+				ID:               path.Join(directory, volume.Name(), chapter.Name()),
+			}
+			result = append(result, md.Chapter{
+				Info:  info,
+				Pages: make(map[int]image.Image, 0),
+			})
+		}
+	}
+
+	return result, nil
+}
+
+func LoadPages(cl md.ChapterList, p formats.Progress) (md.ImageList, error) {
+	result := make(md.ImageList, 0)
+	for _, chap := range cl {
+		pages, err := os.ReadDir(chap.Info.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list '%v': %w", chap.Info.Identifier, err)
+		}
+
+		p.Increase(len(pages))
+		for _, page := range pages {
+			p.Add(1)
+
+			id, err := strconv.Atoi(strings.TrimSuffix(page.Name(), path.Ext(page.Name())))
+			if err != nil {
+				continue
+			}
+
+			f, err := os.Open(path.Join(chap.Info.ID, page.Name()))
+			if err != nil {
+				return nil, err
+			}
+			img, _, err := image.Decode(f)
+			if err != nil {
+				return nil, err
+			}
+
+			result = append(result, md.Image{
+				Image:             img,
+				ImageIdentifier:   id,
+				ChapterIdentifier: chap.Info.Identifier,
+				VolumeIdentifier:  chap.Info.VolumeIdentifier,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+func LoadCovers(directory string, p formats.Progress) (md.ImageList, error) {
+	result := make(md.ImageList, 0)
+	volumes, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, fmt.Errorf("list '%v': %w", directory, err)
+	}
+	p.Increase(len(volumes))
+	for _, volume := range volumes {
+		if !volume.IsDir() {
+			continue
+		}
+
+		img, err := readImage(directory, volume.Name())
+		if err != nil {
+			return nil, fmt.Errorf("image: %w", err)
+		}
+		result = append(result, md.Image{
+			Image:            img,
+			VolumeIdentifier: md.NewIdentifier(volume.Name()),
+		})
+	}
+
+	return result, nil
+}
+
+func readImage(directory, name string) (image.Image, error) {
+	for _, ext := range []string{".jpg", ".jpeg", ".png", ".gif"} {
+		f, err := os.Open(path.Join(directory, name+ext))
+		if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return nil, fmt.Errorf("open: %w", err)
+		} else {
+			img, _, err := image.Decode(f)
+			if err != nil {
+				return nil, fmt.Errorf("decode: %w", err)
+			} else {
+				return img, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no image found")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ var (
 	outArg              string
 	forceArg            bool
 	leftToRightArg      bool
+	diskArg             string
 	cpuprofileArg       string
 	groupsFilter        string
 	chaptersFilter      string
@@ -156,6 +157,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&dryRunArg, "dry-run", "d", false, "disable writing of any files")
 	rootCmd.Flags().StringVarP(&outArg, "out", "o", ".", "output directory")
 	rootCmd.Flags().BoolVarP(&forceArg, "force", "f", false, "overwrite existing volumes")
+	rootCmd.Flags().StringVarP(&diskArg, "disk", "D", "", "load additional content from disk")
 	rootCmd.Flags().StringVarP(&cpuprofileArg, "cpuprofile", "", "", "write CPU profile to this file")
 	rootCmd.Flags().StringVarP(&volumesFilter, "volumes", "V", "", "volume identifiers for chapter downloads")
 	rootCmd.Flags().StringVarP(&chaptersFilter, "chapters", "C", "", "chapter identifiers for chapter downloads")


### PR DESCRIPTION
As discussed in #17, depends on changes introduced in #20.

@Jamerrone this is the PR we talked about, you can try it out if you want. The relevant newly added flag is `--disk`, which takes a directory structure as discussed in #17 to load additional files from.

This PR is not complete yet, I would still like to add the following before merging:

+ [ ] Specifying the name of the scantlation group for chapters read from disk
+ [ ] Specifying whether on-disk chapters should be preferred to MangaDex chapters if both are present