### PR TITLE
Implement: Optionally use Data-Saver

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --data-saver=prefer
 
 ### Fallback to lower quality alternatives for broken images
 
-MangaDex sometimes hosts images that are broken and can not be reliably converted to a format compatible with Kindle e-books.
-Kojirou can be configured to fall back on reencoded lower-quality versions of these images, which are unlikely to also be broken.
+MangaDex sometimes hosts images that are subtly broken and cannot be reliably converted to an image format compatible with Kindle devices.
+Kojirou can be configured to fall back on reencoded lower-quality versions of these images, which often do not have the same problems.
 
 ```
 kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --data-saver=fallback

--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ So, for example, volume "2" would be placed before "10", while "02" would be cor
 kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --fill-volume-number 2
 ```
 
+### Use lower quality images to save space
+
+Kojirou has the ability to download lower-quality images from MangaDex.
+This can be useful to save space on your device, or to reduce the amount of data downloaded on slow or limited connections.
+Legal arguments to this option are "no", "prefer" and "fallback".
+
+```
+kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --data-saver=prefer
+```
+
+### Fallback to lower quality alternatives for broken images
+
+MangaDex sometimes hosts images that are broken and can not be reliably converted to a format compatible with Kindle e-books.
+Kojirou can be configured to fall back on reencoded lower-quality versions of these images, which are unlikely to also be broken.
+
+```
+kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --data-saver=fallback
+```
+
 ## Prebuilt binaries
 
 Prebuilt binaries for Linux, Windows and MacOS on x86 and ARM processors are provided.

--- a/cmd/business.go
+++ b/cmd/business.go
@@ -143,7 +143,7 @@ func getCovers(manga *md.Manga) (md.ImageList, error) {
 func getPages(volume md.Volume, p formats.CliProgress) (md.ImageList, error) {
 	mangadexPages, err := download.MangadexPages(volume.Sorted().FilterBy(func(ci md.ChapterInfo) bool {
 		return ci.GroupNames.String() != "Filesystem"
-	}), p)
+	}), dataSaverArg, p)
 	if err != nil {
 		p.Cancel("Error")
 		return nil, fmt.Errorf("mangadex: %w", err)

--- a/cmd/formats/download/policy.go
+++ b/cmd/formats/download/policy.go
@@ -1,0 +1,45 @@
+package download
+
+import "fmt"
+
+type DataSaverPolicy int
+
+const (
+	DataSaverPolicyNo DataSaverPolicy = iota
+	DataSaverPolicyPrefer
+	DataSaverPolicyFallback
+)
+
+func (p *DataSaverPolicy) String() string {
+	switch *p {
+	case DataSaverPolicyNo:
+		return "no"
+	case DataSaverPolicyPrefer:
+		return "prefer"
+	case DataSaverPolicyFallback:
+		return "fallback"
+	default:
+		panic("unreachable")
+	}
+}
+
+// Set must have pointer receiver so it doesn't change the value of a copy
+func (p *DataSaverPolicy) Set(v string) error {
+	switch v {
+	case "no":
+		*p = DataSaverPolicyNo
+	case "prefer":
+		*p = DataSaverPolicyPrefer
+	case "fallback":
+		*p = DataSaverPolicyFallback
+	default:
+		return fmt.Errorf(`must be one of: "no", "prefer", or "fallback"`)
+	}
+
+	return nil
+}
+
+// Type is only used in help text
+func (p *DataSaverPolicy) Type() string {
+	return "data-saver policy"
+}

--- a/cmd/formats/download/root.go
+++ b/cmd/formats/download/root.go
@@ -178,7 +178,7 @@ func pathsToImages(
 					return nil
 				}
 				eg.Go(func() error {
-					image, err := getImage(httpClient, ctx, path.URL)
+					image, err := getImage(httpClient, ctx, path.DataURL)
 					if err != nil {
 						defer cancel()
 						return fmt.Errorf("chapter %v: image %v: %w", path.ChapterIdentifier, path.ImageIdentifier, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"runtime/pprof"
 
+	"github.com/leotaku/kojirou/cmd/formats/download"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,7 @@ var (
 	forceArg            bool
 	leftToRightArg      bool
 	fillVolumeNumberArg int
+	dataSaverArg        download.DataSaverPolicy
 	diskArg             string
 	cpuprofileArg       string
 	groupsFilter        string
@@ -156,6 +158,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&kindleFolderModeArg, "kindle-folder-mode", "k", false, "generate folder structure for Kindle devices")
 	rootCmd.Flags().BoolVarP(&leftToRightArg, "left-to-right", "p", false, "make reading direction left to right")
 	rootCmd.Flags().IntVarP(&fillVolumeNumberArg, "fill-volume-number", "n", 0, "fill volume number with leading zeros in title")
+	rootCmd.Flags().VarP(&dataSaverArg, "data-saver", "s", "download lower quality images to save space")
 	rootCmd.Flags().BoolVarP(&dryRunArg, "dry-run", "d", false, "disable writing of any files")
 	rootCmd.Flags().StringVarP(&outArg, "out", "o", "", "output directory")
 	rootCmd.Flags().BoolVarP(&forceArg, "force", "f", false, "overwrite existing volumes")

--- a/mangadex/client.go
+++ b/mangadex/client.go
@@ -130,6 +130,8 @@ func (c *Client) FetchPaths(ctx context.Context, chapter *Chapter) (PathList, er
 	ah, err := c.base.GetAtHome(ctx, chapter.Info.ID)
 	if err != nil {
 		return nil, fmt.Errorf("get at home: %w", err)
+	} else if len(ah.Chapter.Data) != len(ah.Chapter.DataSaver) {
+		return nil, fmt.Errorf("broken chapter image list")
 	}
 
 	return convertChapter(chapter, ah), nil

--- a/mangadex/convert.go
+++ b/mangadex/convert.go
@@ -61,7 +61,7 @@ func convertCovers(coverBaseURL string, mangaID string, co []api.CoverData) Path
 	for _, info := range co {
 		url := strings.Join([]string{coverBaseURL, mangaID, info.Attributes.FileName}, "/")
 		result = append(result, Path{
-			URL:               url,
+			DataURL:           url,
 			ImageIdentifier:   0,
 			ChapterIdentifier: NewIdentifier("0"),
 			VolumeIdentifier:  NewWithFallback(info.Attributes.Volume, "Special"),
@@ -73,10 +73,12 @@ func convertCovers(coverBaseURL string, mangaID string, co []api.CoverData) Path
 
 func convertChapter(ch *Chapter, ah *api.AtHome) PathList {
 	result := make(PathList, 0)
-	for i, filename := range ah.Chapter.Data {
-		url := strings.Join([]string{ah.BaseURL, "data", ah.Chapter.Hash, filename}, "/")
+	for i := range ah.Chapter.Data {
+		dataURL := strings.Join([]string{ah.BaseURL, "data", ah.Chapter.Hash, ah.Chapter.Data[i]}, "/")
+		dataSaverURL := strings.Join([]string{ah.BaseURL, "data-saver", ah.Chapter.Hash, ah.Chapter.DataSaver[i]}, "/")
 		result = append(result, Path{
-			URL:               url,
+			DataURL:           dataURL,
+			DataSaverURL:      dataSaverURL,
 			ImageIdentifier:   i,
 			ChapterIdentifier: ch.Info.Identifier,
 			VolumeIdentifier:  ch.Info.VolumeIdentifier,

--- a/mangadex/unstructured.go
+++ b/mangadex/unstructured.go
@@ -41,7 +41,8 @@ type Image struct {
 }
 
 type Path struct {
-	URL string
+	DataURL      string
+	DataSaverURL string
 
 	// identifiers
 	ImageIdentifier   int


### PR DESCRIPTION
This PR implements an option to enable the data-saver functionality, as well as the possibility to fall back on data-saver if downloading the normal images fails. This also represents a fix for issues #6 and #24.

@Colin1224 I would appreciate if you could test these changes and provide feedback. Also, I tried using the GitHub API to create a PR based on your issue, which seems to in the process have replaced the original issue. Sorry about that.