### PR TITLE
Implement: rotate and split options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ Kojirou can be configured to fall back on reencoded lower-quality versions of th
 kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --data-saver=fallback
 ```
 
+### Rotate and split double panel pages
+
+Kojirou has the ability to rotate and split double panel pages into two new pages.
+It's possible to only rotate or rotate and split them.
+
+Only rotating
+``` shell
+kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --rotate
+```
+
+Rotating and splitting
+``` shell
+kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --rotateAndSplit
+```
+
 ## Prebuilt binaries
 
 Prebuilt binaries for Linux, Windows and MacOS on x86 and ARM processors are provided.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,8 @@ var (
 	languageArg         string
 	rankArg             string
 	autocropArg         bool
+	rotateAndSplitArg   bool
+	rotateArg			bool
 	kindleFolderModeArg bool
 	dryRunArg           bool
 	outArg              string
@@ -170,6 +172,8 @@ func init() {
 	rootCmd.Flags().StringVarP(&languageArg, "language", "l", "en", "language for chapter downloads")
 	rootCmd.Flags().StringVarP(&rankArg, "rank", "r", "most", "chapter ranking method to use")
 	rootCmd.Flags().BoolVarP(&autocropArg, "autocrop", "a", false, "crop whitespace from pages automatically")
+	rootCmd.Flags().BoolVarP(&rotateAndSplitArg, "rotateAndSplit", "S", false, "rotate and split double panels pages into two new separate pages")
+	rootCmd.Flags().BoolVarP(&rotateArg, "rotate", "H", false, "rotate horizontally double panels pages")
 	rootCmd.Flags().BoolVarP(&kindleFolderModeArg, "kindle-folder-mode", "k", false, "generate folder structure for Kindle devices")
 	rootCmd.Flags().BoolVarP(&leftToRightArg, "left-to-right", "p", false, "make reading direction left to right")
 	rootCmd.Flags().IntVarP(&fillVolumeNumberArg, "fill-volume-number", "n", 0, "fill volume number with leading zeros in title")

--- a/cmd/split/root.go
+++ b/cmd/split/root.go
@@ -1,0 +1,66 @@
+package split
+
+import (
+	"fmt"
+	"image"
+)
+
+func IsDoublePage(img image.Image) bool {
+	bounds := img.Bounds()
+	return bounds.Dx() >= bounds.Dy()
+}
+
+func GetNextImageIdentifier(current int, occupied map[int]bool) int {
+	// while the current identifier is already occupied, increment it
+	for occupied[current] {
+		current++
+	}
+	return current
+}
+
+func SplitVertically(img image.Image) (image.Image, image.Image, error) {
+	type subImager interface {
+		image.Image
+		SubImage(r image.Rectangle) image.Image
+	}
+
+	subImg, ok := img.(subImager)
+	if !ok {
+		return nil, nil, fmt.Errorf("image does not support splitting or not a valid image")
+	}
+
+	originalBounds := subImg.Bounds()
+	xMiddle := originalBounds.Dx() / 2
+
+	leftBounds := image.Rectangle{
+		Min: image.Point{0, 0},
+		Max: image.Point{xMiddle, originalBounds.Dy()},
+	}
+	rightBounds := image.Rectangle{
+		Min: image.Point{xMiddle, 0},
+		Max: image.Point{originalBounds.Dx(), originalBounds.Dy()},
+	}
+
+	leftImage := subImg.SubImage(leftBounds)
+	rightImage := subImg.SubImage(rightBounds)
+
+	return leftImage, rightImage, nil
+}
+
+func RotateImage(img image.Image) (image.Image, error) {
+	originalBounds := img.Bounds()
+	width := originalBounds.Dx()
+	height := originalBounds.Dy()
+
+	// create a new empty image with rotated dimensions
+	rotatedImage := image.NewRGBA(image.Rect(0, 0, height, width))
+
+	// rotate the image by mapping each pixel from the original to the new position
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			rotatedImage.Set(y, width-1-x, img.At(x, y))
+		}
+	}
+
+	return rotatedImage, nil
+}


### PR DESCRIPTION
Hello! This PR resolves #44 that I opened about being able to rotate and split double panel images. 

I try implementing it by myself, but, this is the first time that I wrote something in go.

All mangas that I downloaded with the news options worked just fine, but, the code itself can be a bit messy. Feel free to point to anything that you want me to modify in it.

What I added is:

Rotate and split double panel pages into two new pages.
It's possible to only rotate or rotate and split them.

Only rotating

> --rotate or -H (H because Horizontally Rotate)

``` shell
kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --rotate
```

Rotating and splitting

> --rotateAndSplit or -S (S because Split)

``` shell
kojirou d86cf65b-5f6c-437d-a0af-19a31f94ec55 -l en --rotateAndSplit
```

If the line includes both of them, --rotateAndSplit will be the major one, --rotate still will run but it won't modify anything.

Anyway, before anything, thanks !
It really was a fun code to modify !