### PR TITLE
feat: --save-raw or -S to save raw images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+raw_images

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 raw_images
+kojirou.exe
+kojirou

--- a/cmd/business.go
+++ b/cmd/business.go
@@ -141,7 +141,7 @@ func getCovers(manga *md.Manga) (md.ImageList, error) {
 func getPages(volume md.Volume, p formats.CliProgress) (md.ImageList, error) {
 	mangadexPages, err := download.MangadexPages(volume.Sorted().FilterBy(func(ci md.ChapterInfo) bool {
 		return ci.GroupNames.String() != "Filesystem"
-	}), download.DataSaverPolicy(dataSaverArg), p)
+	}), download.DataSaverPolicy(dataSaverArg), saveRawArg, p)
 	if err != nil {
 		p.Cancel("Error")
 		return nil, fmt.Errorf("mangadex: %w", err)

--- a/cmd/business.go
+++ b/cmd/business.go
@@ -52,7 +52,7 @@ func handleVolume(skeleton md.Manga, volume md.Volume, dir kindle.NormalizedDire
 		return nil
 	}
 
-	pages, err := getPages(volume, p)
+	pages, err := getPages(volume, skeleton.Info.Title, p)
 	if err != nil {
 		return fmt.Errorf("pages: %w", err)
 	}
@@ -114,7 +114,7 @@ func getChapters(manga md.Manga) (md.ChapterList, error) {
 
 func getCovers(manga *md.Manga) (md.ImageList, error) {
 	p := formats.VanishingProgress("Covers")
-	covers, err := download.MangadexCovers(manga, saveRawArg, p)
+	covers, err := download.MangadexCovers(manga, saveRawArg, fillVolumeNumberArg, p)
 	if err != nil {
 		p.Cancel("Error")
 		return nil, fmt.Errorf("mangadex: %w", err)
@@ -138,10 +138,10 @@ func getCovers(manga *md.Manga) (md.ImageList, error) {
 	return covers, nil
 }
 
-func getPages(volume md.Volume, p formats.CliProgress) (md.ImageList, error) {
+func getPages(volume md.Volume, mangaTitle string, p formats.CliProgress) (md.ImageList, error) {
 	mangadexPages, err := download.MangadexPages(volume.Sorted().FilterBy(func(ci md.ChapterInfo) bool {
 		return ci.GroupNames.String() != "Filesystem"
-	}), download.DataSaverPolicy(dataSaverArg), saveRawArg, p)
+	}), download.DataSaverPolicy(dataSaverArg), saveRawArg, fillVolumeNumberArg, mangaTitle, p)
 	if err != nil {
 		p.Cancel("Error")
 		return nil, fmt.Errorf("mangadex: %w", err)

--- a/cmd/business.go
+++ b/cmd/business.go
@@ -114,7 +114,7 @@ func getChapters(manga md.Manga) (md.ChapterList, error) {
 
 func getCovers(manga *md.Manga) (md.ImageList, error) {
 	p := formats.VanishingProgress("Covers")
-	covers, err := download.MangadexCovers(manga, p)
+	covers, err := download.MangadexCovers(manga, saveRawArg, p)
 	if err != nil {
 		p.Cancel("Error")
 		return nil, fmt.Errorf("mangadex: %w", err)

--- a/cmd/formats/download/root.go
+++ b/cmd/formats/download/root.go
@@ -57,7 +57,7 @@ func MangadexChapters(mangaID string) (md.ChapterList, error) {
 	return mangadexClient.FetchChapters(context.TODO(), mangaID)
 }
 
-func MangadexCovers(manga *md.Manga, saveRawArg bool, p formats.Progress) (md.ImageList, error) {
+func MangadexCovers(manga *md.Manga, saveRawArg bool, fillVolumeNumberArg int, p formats.Progress) (md.ImageList, error) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -77,7 +77,7 @@ func MangadexCovers(manga *md.Manga, saveRawArg bool, p formats.Progress) (md.Im
 		close(coverPaths)
 	}()
 
-	coverImages, eg := pathsToImages(coverPaths, ctx, cancel, DataSaverPolicyNo, saveRawArg)
+	coverImages, eg := pathsToImages(coverPaths, ctx, cancel, DataSaverPolicyNo, saveRawArg, fillVolumeNumberArg, manga.Info.Title)
 
 	results := make(md.ImageList, len(covers))
 	for coverImage := range coverImages {
@@ -92,7 +92,14 @@ func MangadexCovers(manga *md.Manga, saveRawArg bool, p formats.Progress) (md.Im
 	}
 }
 
-func MangadexPages(chapterList md.ChapterList, policy DataSaverPolicy, saveRawArg bool, p formats.Progress) (md.ImageList, error) {
+func MangadexPages(
+	chapterList md.ChapterList,
+	policy DataSaverPolicy,
+	saveRawArg bool,
+	fillVolumeNumberArg int,
+	mangaTitle string,
+	p formats.Progress,
+) (md.ImageList, error) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -110,7 +117,7 @@ func MangadexPages(chapterList md.ChapterList, policy DataSaverPolicy, saveRawAr
 	paths, childEg := chaptersToPaths(chapters, ctx, cancel, p)
 	eg.Go(childEg.Wait)
 
-	images, childEg := pathsToImages(paths, ctx, cancel, policy, saveRawArg)
+	images, childEg := pathsToImages(paths, ctx, cancel, policy, saveRawArg, fillVolumeNumberArg, mangaTitle)
 	eg.Go(childEg.Wait)
 
 	results := make(md.ImageList, 0)
@@ -181,6 +188,8 @@ func pathsToImages(
 	cancel context.CancelFunc,
 	policy DataSaverPolicy,
 	saveRawArg bool,
+	fillVolumeNumberArg int,
+	mangaTitle string,
 ) (<-chan md.Image, *errgroup.Group) {
 	ch := make(chan md.Image)
 	eg, ctx := errgroup.WithContext(ctx)
@@ -196,7 +205,7 @@ func pathsToImages(
 					return nil
 				}
 				eg.Go(func() error {
-					img, err := getImageWithPolicy(httpClient, ctx, path, policy, saveRawArg)
+					img, err := getImageWithPolicy(httpClient, ctx, path, policy, saveRawArg, fillVolumeNumberArg, mangaTitle)
 					if err != nil {
 						defer cancel()
 						return fmt.Errorf("chapter %v: image %v: %w", path.ChapterIdentifier, path.ImageIdentifier, err)
@@ -221,7 +230,15 @@ func pathsToImages(
 	return ch, eg
 }
 
-func getImageWithPolicy(client *http.Client, ctx context.Context, path md.Path, policy DataSaverPolicy, saveRawArg bool) (image.Image, error) {
+func getImageWithPolicy(
+	client *http.Client,
+	ctx context.Context,
+	path md.Path,
+	policy DataSaverPolicy,
+	saveRawArg bool,
+	fillVolumeNumberArg int,
+	mangaTitle string,
+) (image.Image, error) {
 	resp := new(http.Response)
 	err := error(nil)
 
@@ -240,14 +257,14 @@ func getImageWithPolicy(client *http.Client, ctx context.Context, path md.Path, 
 	defer resp.Body.Close()
 
 	if err != nil && policy == DataSaverPolicyFallback {
-		return getImageWithPolicy(client, ctx, path, DataSaverPolicyPrefer, saveRawArg)
+		return getImageWithPolicy(client, ctx, path, DataSaverPolicyPrefer, saveRawArg, fillVolumeNumberArg, mangaTitle)
 	} else if err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 
 	if saveRawArg {
 		// Save the image to a temporary directory
-		tempDir := filepath.Join("raw_images", fmt.Sprintf("Volume %s", path.VolumeIdentifier))
+		tempDir := filepath.Join("raw_images", mangaTitle, "Volume "+path.VolumeIdentifier.StringFilled(fillVolumeNumberArg, 0, false))
 		// if chapter id & img id are both 0, it's a cover image
 		if !(path.ChapterIdentifier.String() == "0" && path.ImageIdentifier == 0) {
 			tempDir = filepath.Join(tempDir, fmt.Sprintf("Chapter %s", path.ChapterIdentifier))

--- a/cmd/formats/download/root.go
+++ b/cmd/formats/download/root.go
@@ -57,7 +57,7 @@ func MangadexChapters(mangaID string) (md.ChapterList, error) {
 	return mangadexClient.FetchChapters(context.TODO(), mangaID)
 }
 
-func MangadexCovers(manga *md.Manga, p formats.Progress) (md.ImageList, error) {
+func MangadexCovers(manga *md.Manga, saveRawArg bool, p formats.Progress) (md.ImageList, error) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -77,7 +77,7 @@ func MangadexCovers(manga *md.Manga, p formats.Progress) (md.ImageList, error) {
 		close(coverPaths)
 	}()
 
-	coverImages, eg := pathsToImages(coverPaths, ctx, cancel, DataSaverPolicyNo, true)
+	coverImages, eg := pathsToImages(coverPaths, ctx, cancel, DataSaverPolicyNo, saveRawArg)
 
 	results := make(md.ImageList, len(covers))
 	for coverImage := range coverImages {

--- a/cmd/formats/download/root.go
+++ b/cmd/formats/download/root.go
@@ -7,7 +7,6 @@ import (
 	"image"
 	_ "image/gif"
 	"image/jpeg"
-	_ "image/jpeg"
 	_ "image/png"
 	"io"
 	"net/http"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ var (
 	volumesFilter       string
 	helpRankingFlag     bool
 	helpFilterFlag      bool
+	saveRawArg          bool
 )
 
 var rootCmd = &cobra.Command{
@@ -186,6 +187,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&groupsFilter, "groups", "G", "", "scantlation groups for chapter downloads")
 	rootCmd.Flags().BoolVarP(&helpRankingFlag, "help-ranking", "R", false, "Help for chapter ranking")
 	rootCmd.Flags().BoolVarP(&helpFilterFlag, "help-filter", "F", false, "Help for chapter filtering")
+	rootCmd.Flags().BoolVarP(&saveRawArg, "save-raw", "S", false, "save raw images to disk")
 	rootCmd.Flags().SortFlags = false
 	rootCmd.Flags().MarkHidden("cpuprofile") //nolint:errcheck
 	rootCmd.Flags().MarkHidden("memprofile") //nolint:errcheck


### PR DESCRIPTION
For https://github.com/leotaku/kojirou/issues/48

I don't know golang, so this is a very minimal work to make it work. Feel free to discard the PR and rework it 😄.

Using `--save-raw` or `-S` will now save to `raw_images` directory with structure like this:

```
raw_images
└── Manga Title
    └── Volume 01
        └── cover.jpg
        └── Chapter 1
            └── 1.jpg
            └── 2.jpg
            └── 3.jpg
            └── ...
```